### PR TITLE
Install API dependencies and envsubst in Docker image

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
 
 # Systemdienste
 RUN apt-get update \
- && apt-get install -y --no-install-recommends nginx supervisor wget ca-certificates \
+ && apt-get install -y --no-install-recommends nginx supervisor wget ca-certificates gettext-base \
  && rm -rf /var/lib/apt/lists/*
 
 # Arbeitsverzeichnis
@@ -16,7 +16,11 @@ COPY api /app/api
 
 # Python-Abhängigkeiten der API (falls vorhanden)
 WORKDIR /app/api
-RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; fi
+RUN if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    elif [ -f ebay-kleinanzeigen-api/requirements.txt ]; then \
+        pip install --no-cache-dir -r ebay-kleinanzeigen-api/requirements.txt; \
+    fi
 
 # Nginx & Supervisor Konfigs (liegen unter ops/)
 WORKDIR /app

--- a/ops/start-nginx.sh
+++ b/ops/start-nginx.sh
@@ -3,5 +3,7 @@ set -e
 : "${ORS_API_KEY:?ORS_API_KEY not set}"
 : "${SEARCH_RADIUS_KM:=10}"
 : "${STEP_KM:=50}"
-envsubst '${ORS_API_KEY} ${SEARCH_RADIUS_KM} ${STEP_KM}' < /usr/share/nginx/html/config.js.template > /usr/share/nginx/html/config.js
+envsubst '${ORS_API_KEY} ${SEARCH_RADIUS_KM} ${STEP_KM}' \
+    < /usr/share/nginx/html/config.js.template \
+    > /usr/share/nginx/html/config.js
 exec /usr/sbin/nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- ensure Docker image installs uvicorn and related API dependencies via submodule requirements
- add gettext-base so `envsubst` is available for config templating
- format `start-nginx.sh` for readability

## Testing
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a82736256883258333af1fd417176e