### PR TITLE
Install uvicorn in suite container

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -22,6 +22,9 @@ RUN if [ -f requirements.txt ]; then \
         pip install --no-cache-dir -r ebay-kleinanzeigen-api/requirements.txt; \
     fi
 
+# ensure uvicorn is available even if no requirements file is present
+RUN pip install --no-cache-dir uvicorn
+
 # Nginx & Supervisor Konfigs (liegen unter ops/)
 WORKDIR /app
 COPY ops/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
## Summary
- install uvicorn during container build so supervisor can launch API

## Testing
- `docker compose build kleinanzeigen_suite` (fails: command not found: docker)

------
https://chatgpt.com/codex/tasks/task_b_68a82817634c8325b9cdda986c77cfcc