### PR TITLE
Add placeholder FastAPI app for API service

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,1 @@
+fastapi


### PR DESCRIPTION
## Summary
- provide minimal FastAPI `main` module with `/health` endpoint
- declare FastAPI dependency for API build

## Testing
- `python -m py_compile api/main.py`
- `docker compose build kleinanzeigen_suite` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a828d4e67c8325b84d6d4c083f623b