### PR TITLE
Add placeholder inserate endpoint and env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in your OpenRouteService API key.
+# Values in this file act as defaults and documentation.
+
+ORS_API_KEY=CHANGE_ME
+SEARCH_RADIUS_KM=10
+STEP_KM=50

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,16 @@
+"""API service for kleinanzeigen_suite.
+
+This module exposes a minimal FastAPI application that currently provides a
+health-check endpoint and a placeholder search endpoint used by the web
+frontend.  The original implementation only offered ``/health`` which caused
+404 errors when the frontend attempted to query ``/inserate``.  To avoid those
+errors the corresponding route is now implemented and returns an empty result
+set.  This keeps the interface stable until real search functionality is
+implemented.
+"""
+
 from fastapi import FastAPI
+
 
 app = FastAPI()
 
@@ -7,3 +19,28 @@ app = FastAPI()
 async def health() -> dict[str, str]:
     """Simple health check endpoint."""
     return {"status": "ok"}
+
+
+@app.get("/inserate")
+@app.get("/api/inserate")
+async def inserate(query: str, location: str, radius: int = 10) -> dict[str, list]:
+    """Placeholder endpoint returning no classifieds.
+
+    Parameters
+    ----------
+    query:
+        Search term for the classifieds.
+    location:
+        Postal code used as search origin.
+    radius:
+        Search radius in kilometres. Defaults to ``10``.
+
+    Returns
+    -------
+    dict
+        A dictionary with a ``data`` key containing an empty list.  The shape
+        matches the structure expected by the frontend which avoids runtime
+        errors while the real implementation is pending.
+    """
+
+    return {"data": []}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,6 @@ services:
     shm_size: "1g"
     ipc: host
     environment:
-      ORS_API_KEY: "CHANGE_ME"
-      SEARCH_RADIUS_KM: "10"
-      STEP_KM: "50"
+      ORS_API_KEY: ${ORS_API_KEY}
+      SEARCH_RADIUS_KM: ${SEARCH_RADIUS_KM:-10}
+      STEP_KM: ${STEP_KM:-50}


### PR DESCRIPTION
## Summary
- expose `/inserate` API to avoid 404s from the frontend and return empty result set for now
- read environment values for API via docker-compose and provide `.env.example`
- ignore developer-specific `.env` files

## Testing
- `python -m py_compile api/main.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a82ae0656883259737b89dde3259ee