### PR TITLE
Disable supervisor stdout/stderr log rotation

### DIFF
--- a/ops/supervisord.conf
+++ b/ops/supervisord.conf
@@ -9,6 +9,8 @@ autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
 startretries=3
 
 [program:nginx]
@@ -17,4 +19,6 @@ autostart=true
 autorestart=true
 stdout_logfile=/dev/stdout
 stderr_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
 startretries=3


### PR DESCRIPTION
## Summary
- avoid OSError by disabling Supervisor log rotation on stdout/stderr for uvicorn and nginx

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a82c2f8b608325b86773461f344347