### PR TITLE
Clone Kleinanzeigen API during Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 __pycache__/
+api/ebay-kleinanzeigen-api/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "api/ebay-kleinanzeigen-api"]
-	path = api/ebay-kleinanzeigen-api
-	url = https://github.com/DanielWTE/ebay-kleinanzeigen-api

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -5,17 +5,18 @@ ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
 
 # Systemdienste
 RUN apt-get update \
- && apt-get install -y --no-install-recommends nginx supervisor wget ca-certificates gettext-base \
+ && apt-get install -y --no-install-recommends nginx supervisor wget ca-certificates gettext-base git \
  && rm -rf /var/lib/apt/lists/*
 
 # Arbeitsverzeichnis
 WORKDIR /app
 
-# Upstream-API unverändert hinein (Kontext = Projekt-Root!)
+# Upstream-API (Kleinanzeigen-Scraper) dynamisch nachziehen
 COPY api /app/api
+WORKDIR /app/api
+RUN git clone --depth=1 https://github.com/DanielWTE/ebay-kleinanzeigen-api.git ebay-kleinanzeigen-api
 
 # Python-Abhängigkeiten der API (falls vorhanden)
-WORKDIR /app/api
 RUN if [ -f requirements.txt ]; then \
         pip install --no-cache-dir -r requirements.txt; \
     elif [ -f ebay-kleinanzeigen-api/requirements.txt ]; then \


### PR DESCRIPTION
## Summary
- remove git submodule for ebay-kleinanzeigen-api
- clone Kleinanzeigen API during Docker image build so repo works without manual submodule init
- ensure Docker build has git available and ignore cloned API directory

## Testing
- `python -m py_compile api/main.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a82d13d66883258d6218d5d89f416a