### PR TITLE
Handle existing API clone in Dockerfile

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -14,7 +14,11 @@ WORKDIR /app
 # Upstream-API (Kleinanzeigen-Scraper) dynamisch nachziehen
 COPY api /app/api
 WORKDIR /app/api
-RUN git clone --depth=1 https://github.com/DanielWTE/ebay-kleinanzeigen-api.git ebay-kleinanzeigen-api
+RUN if [ ! -d ebay-kleinanzeigen-api ]; then \
+        git clone --depth=1 https://github.com/DanielWTE/ebay-kleinanzeigen-api.git ebay-kleinanzeigen-api; \
+    else \
+        cd ebay-kleinanzeigen-api && git pull; \
+    fi
 
 # Python-Abhängigkeiten der API (falls vorhanden)
 RUN if [ -f requirements.txt ]; then \


### PR DESCRIPTION
## Summary
- Avoid Docker build failures when the ebay-kleinanzeigen-api folder already exists by conditionally cloning or pulling

## Testing
- `python -m py_compile api/main.py`
- `docker build -f ops/Dockerfile . -t test-image` *(fails: command not found: docker)*
- `sudo apt-get update && sudo apt-get install -y docker.io` *(fails: 403  Forbidden [IP: 172.30.1.211 8080])*

------
https://chatgpt.com/codex/tasks/task_b_68a82f494a2c8325a9a5fc6d04a1db27