### PR TITLE
Handle existing API clone in Dockerfile

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -14,7 +14,12 @@ WORKDIR /app
 # Upstream-API (Kleinanzeigen-Scraper) dynamisch nachziehen
 COPY api /app/api
 WORKDIR /app/api
-RUN git clone --depth=1 https://github.com/DanielWTE/ebay-kleinanzeigen-api.git ebay-kleinanzeigen-api
+RUN if [ -d ebay-kleinanzeigen-api/.git ]; then \
+        git -C ebay-kleinanzeigen-api pull; \
+    else \
+        rm -rf ebay-kleinanzeigen-api && \
+        git clone --depth=1 https://github.com/DanielWTE/ebay-kleinanzeigen-api.git ebay-kleinanzeigen-api; \
+    fi
 
 # Python-Abhängigkeiten der API (falls vorhanden)
 RUN if [ -f requirements.txt ]; then \


### PR DESCRIPTION
## Summary
- Ensure Docker build reuses or refreshes `ebay-kleinanzeigen-api` by pulling if a valid git repo exists or recloning after removing stale directories

## Testing
- `python -m py_compile api/main.py`
- `docker build -f ops/Dockerfile . -t test-image` *(fails: command not found: docker)*
- `sudo apt-get update && sudo apt-get install -y docker.io` *(fails: 403  Forbidden [IP: 172.30.2.19 8080])*

------
https://chatgpt.com/codex/tasks/task_b_68a82f494a2c8325a9a5fc6d04a1db27