### PR TITLE
Simplify API clone in Dockerfile

### DIFF
--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -14,11 +14,8 @@ WORKDIR /app
 # Upstream-API (Kleinanzeigen-Scraper) dynamisch nachziehen
 COPY api /app/api
 WORKDIR /app/api
-RUN if [ ! -d ebay-kleinanzeigen-api ]; then \
-        git clone --depth=1 https://github.com/DanielWTE/ebay-kleinanzeigen-api.git ebay-kleinanzeigen-api; \
-    else \
-        cd ebay-kleinanzeigen-api && git pull; \
-    fi
+RUN rm -rf ebay-kleinanzeigen-api && \
+    git clone --depth=1 https://github.com/DanielWTE/ebay-kleinanzeigen-api.git ebay-kleinanzeigen-api
 
 # Python-Abhängigkeiten der API (falls vorhanden)
 RUN if [ -f requirements.txt ]; then \


### PR DESCRIPTION
## Summary
- Always re-clone `ebay-kleinanzeigen-api` during Docker build to avoid failing `git pull`

## Testing
- `python -m py_compile api/*.py`


------
https://chatgpt.com/codex/tasks/task_b_68a8309961208325b62bceac6892d5e8