### PR TITLE
feat: integrate ebay search

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,15 +1,28 @@
-"""API service for kleinanzeigen_suite.
+"""API service for :mod:`kleinanzeigen_suite`.
 
-This module exposes a minimal FastAPI application that currently provides a
-health-check endpoint and a placeholder search endpoint used by the web
-frontend.  The original implementation only offered ``/health`` which caused
-404 errors when the frontend attempted to query ``/inserate``.  To avoid those
-errors the corresponding route is now implemented and returns an empty result
-set.  This keeps the interface stable until real search functionality is
-implemented.
+Previously the application exposed only a health-check endpoint and returned
+an empty payload for ``/inserate``.  This file now wires up the real
+``ebay-kleinanzeigen-api`` scraper so that search queries return actual
+classified ads instead of a static placeholder.
 """
 
-from fastapi import FastAPI
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+
+
+# Make the bundled ``ebay-kleinanzeigen-api`` package importable.  The
+# Dockerfile clones the upstream repository into ``api/ebay-kleinanzeigen-api``
+# so we simply add that directory to ``sys.path`` here.
+SCRAPER_DIR = Path(__file__).resolve().parent / "ebay-kleinanzeigen-api"
+sys.path.insert(0, str(SCRAPER_DIR))
+
+from scrapers.inserate import get_inserate_klaz  # type: ignore  # noqa: E402
+from utils.browser import PlaywrightManager  # type: ignore  # noqa: E402
 
 
 app = FastAPI()
@@ -23,8 +36,15 @@ async def health() -> dict[str, str]:
 
 @app.get("/inserate")
 @app.get("/api/inserate")
-async def inserate(query: str, location: str, radius: int = 10) -> dict[str, list]:
-    """Placeholder endpoint returning no classifieds.
+async def inserate(
+    query: str,
+    location: str,
+    radius: int = 10,
+    min_price: Optional[int] = None,
+    max_price: Optional[int] = None,
+    page_count: int = 1,
+) -> dict[str, list]:
+    """Return classifieds scraped from eBay Kleinanzeigen.
 
     Parameters
     ----------
@@ -34,13 +54,33 @@ async def inserate(query: str, location: str, radius: int = 10) -> dict[str, lis
         Postal code used as search origin.
     radius:
         Search radius in kilometres. Defaults to ``10``.
+    min_price, max_price:
+        Optional price filters in Euro.
+    page_count:
+        Number of result pages to fetch.  The upstream scraper supports up to
+        20 pages.
 
     Returns
     -------
     dict
-        A dictionary with a ``data`` key containing an empty list.  The shape
-        matches the structure expected by the frontend which avoids runtime
-        errors while the real implementation is pending.
+        A dictionary with a ``data`` key containing the scraped classifieds.
     """
 
-    return {"data": []}
+    browser_manager = PlaywrightManager()
+    await browser_manager.start()
+    try:
+        results = await get_inserate_klaz(
+            browser_manager,
+            query,
+            location,
+            radius,
+            min_price,
+            max_price,
+            page_count,
+        )
+    except Exception as exc:  # pragma: no cover - defensive programming
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        await browser_manager.close()
+
+    return {"data": results}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,1 +1,3 @@
 fastapi
+playwright
+python-multipart


### PR DESCRIPTION
## Summary
- connect `/inserate` endpoint to upstream `ebay-kleinanzeigen-api` scraper
- expose optional search filters and return real classifieds
- add Playwright and multipart dependencies

## Testing
- `pip install -r api/requirements.txt`
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68a831ae89d483259a400860297d1a2c