### PR TITLE
Animate progress bar and toggle search UI

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -8,6 +8,7 @@
   /* Links im Darkmode */
   a, a:visited{color:#b4c7ff;text-decoration:none}
   a:hover{color:#d5e2ff;text-decoration:underline}
+  .hidden{display:none!important}
 
   /* App Header */
   .app-header{

--- a/web/route.html
+++ b/web/route.html
@@ -14,27 +14,27 @@
 </div>
 
 <header>
-  <div class="group suggest">
+  <div class="group suggest" id="grpStart">
     <label for="start">Start</label>
     <input id="start" placeholder="Adresse/Ort eingeben" autocomplete="off">
     <ul id="start-suggest" hidden></ul>
   </div>
-  <div class="group suggest">
+  <div class="group suggest" id="grpZiel">
     <label for="ziel">Ziel</label>
     <input id="ziel" placeholder="Adresse/Ort eingeben" autocomplete="off">
     <ul id="ziel-suggest" hidden></ul>
   </div>
-  <div class="group">
+  <div class="group" id="grpQuery">
     <label for="query">Suchbegriff</label>
     <input id="query" placeholder="Suchbegriff">
   </div>
-  <div class="group">
+  <div class="group" id="grpRun">
     <label>&nbsp;</label>
     <button id="btnRun">Route berechnen &amp; suchen</button>
   </div>
 </header>
 
-<div id="map-box">
+<div id="map-box" class="hidden">
   <div id="map-progress"><div id="progressBar" class="bar"></div><span id="progressText" class="pct">0%</span></div>
   <div id="map"></div>
 </div>

--- a/web/route.js
+++ b/web/route.js
@@ -25,6 +25,7 @@ const resultMarkers = L.layerGroup().addTo(map);
 
 // Shorthands
 const $=sel=>document.querySelector(sel);
+const startGroup=$("#grpStart"), zielGroup=$("#grpZiel"), queryGroup=$("#grpQuery"), runGroup=$("#grpRun"), mapBox=$("#map-box");
 // Progress-Helfer
 function setProgress(pct){
   const bar = $("#progressBar"), txt = $("#progressText");
@@ -35,7 +36,12 @@ function setProgress(pct){
 function setProgressState(state /* 'active' | 'done' | 'aborted' */, msg){
   const bar = $("#progressBar"), txt = $("#progressText");
   bar.classList.remove("active","done","aborted");
-  if(state) bar.classList.add(state);
+  if(state){
+    bar.classList.add(state);
+    bar.style.animation = state==="active" ? "stripe 1.2s linear infinite" : "";
+  } else {
+    bar.style.animation = "";
+  }
   if(msg) txt.textContent = msg;
 }
 
@@ -383,13 +389,22 @@ $("#btnRun").addEventListener("click",()=>{
     setStatus("Suche abgebrochen.", true);
     setProgressState("aborted", "Abgebrochen");
     $("#btnRun").textContent="Route berechnen & suchen";
+    startGroup.classList.remove("hidden");
+    zielGroup.classList.remove("hidden");
+    queryGroup.classList.remove("hidden");
+    mapBox.classList.add("hidden");
   } else {
     run();
   }
 });
 
 async function run(){
-running=true; $("#btnRun").textContent="Stop";
+running=true; $("#btnRun").textContent="Abbrechen";
+startGroup.classList.add("hidden");
+zielGroup.classList.add("hidden");
+queryGroup.classList.add("hidden");
+mapBox.classList.remove("hidden");
+map.invalidateSize();
 clearResults(); resetStatus();
 setProgressState("active");           // animierte Streifen an
 setProgress(0);
@@ -410,6 +425,10 @@ catch(e){
   running=false;
   setProgressState("aborted","Abgebrochen");
   $("#btnRun").textContent="Route berechnen & suchen";
+  startGroup.classList.remove("hidden");
+  zielGroup.classList.remove("hidden");
+  queryGroup.classList.remove("hidden");
+  mapBox.classList.add("hidden");
   return;
 }
 
@@ -525,13 +544,18 @@ catch(e){
       }
     }
 
-    await Promise.all(Array.from({length:WORKERS},()=>worker()));
-setStatus("Fertig.");
-setProgress(100);
-setProgressState("done", `Fertig – ${totalFound} Inserate`);
+      await Promise.all(Array.from({length:WORKERS},()=>worker()));
+  setStatus("Fertig.");
+  setProgress(100);
+  setProgressState("done", `Fertig – ${totalFound} Inserate`);
+  runGroup.classList.add("hidden");
 }catch(e){
   setStatus(e.message,true);
   setProgressState("aborted","Abgebrochen");
+  startGroup.classList.remove("hidden");
+  zielGroup.classList.remove("hidden");
+  queryGroup.classList.remove("hidden");
+  mapBox.classList.add("hidden");
 }
 running=false; $("#btnRun").textContent="Route berechnen & suchen";
 }


### PR DESCRIPTION
## Summary
- animate progress bar stripes during search
- hide search inputs and show map only while searching
- reveal results only after completion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a843d1bc7c8325aafc5d417b93120d