### PR TITLE
Hide status panel and smooth progress bar animation

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -78,6 +78,7 @@
   background-size:48px 48px;
   background-position:0 0;
   animation:stripe 1.2s linear infinite;
+  will-change: background-position;
 }
 /* fertig (grün, keine Animation) */
 #map-progress .bar.done{
@@ -154,13 +155,6 @@
   @media (max-width: 768px){
     .gallery-item { flex: 0 1 calc(50% - 12px); } /* 2 pro Zeile (Mobile) */
   }
-
-  /* Status pretty with <details> */
-  details{background:var(--card);border:1px solid var(--border);border-radius:10px}
-  summary{cursor:pointer;padding:10px 12px;font-weight:700;border-bottom:1px solid var(--border);list-style:none}
-  summary::marker,summary::-webkit-details-marker{display:none}
-  #status{padding:12px;max-height:260px;overflow:auto}
-  .ok{color:var(--ok)} .err{color:var(--err)}
 
   /* Popups Darkmode + Scrollbar */
   .leaflet-popup-content-wrapper{

--- a/web/route.html
+++ b/web/route.html
@@ -40,11 +40,7 @@
 </div>
 
 <div id="panel">
-  <div id="results"><strong>Ergebnisliste</strong><div class="row">Noch keine Suche.</div></div>
-  <details id="statusWrap">
-    <summary>Status ▼</summary>
-    <div id="status"><strong>Status</strong> Bereit.</div>
-  </details>
+  <div id="results" class="hidden"><strong>Ergebnisliste</strong></div>
 </div>
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>

--- a/web/route.js
+++ b/web/route.js
@@ -36,18 +36,13 @@ function setProgress(pct){
 function setProgressState(state /* 'active' | 'done' | 'aborted' */, msg){
   const bar = $("#progressBar"), txt = $("#progressText");
   bar.classList.remove("active","done","aborted");
-  if(state){
-    bar.classList.add(state);
-    bar.style.animation = state==="active" ? "stripe 1.2s linear infinite" : "";
-  } else {
-    bar.style.animation = "";
-  }
+  if(state) bar.classList.add(state);
   if(msg) txt.textContent = msg;
 }
 
-// -------- Status --------
-function setStatus(msg,isErr=false){const s=$("#status");const line=document.createElement("div");line.textContent=msg;line.className=isErr?"err":"ok";s.appendChild(line);}
-function resetStatus(){const s=$("#status");s.innerHTML="<strong>Status</strong> ";}
+// -------- Status (nur Konsole) --------
+function setStatus(msg,isErr=false){ (isErr?console.error:console.log)(msg); }
+function resetStatus(){}
 
 // -------- Ergebnisliste: gruppiert + Galerie --------
 const groups = new Map(); // key -> details element
@@ -404,8 +399,9 @@ startGroup.classList.add("hidden");
 zielGroup.classList.add("hidden");
 queryGroup.classList.add("hidden");
 mapBox.classList.remove("hidden");
+$("#results").classList.remove("hidden");
 map.invalidateSize();
-clearResults(); resetStatus();
+clearResults();
 setProgressState("active");           // animierte Streifen an
 setProgress(0);
 let totalFound = 0;                   // Trefferzähler für "Fertig"-Text


### PR DESCRIPTION
## Summary
- remove status panel from the web UI and log messages to console only
- smooth progress bar stripes using CSS `will-change`
- delay showing result list until search begins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a846aaceb08325a494379eeb8fcf2a