### PR TITLE
Improve progress bar and location autocomplete

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -69,15 +69,10 @@
 }
 /* läuft + animiert */
 #map-progress .bar.active{
-  background:
-    repeating-linear-gradient(
-      45deg,
-      #2563eb 0 12px,
-      #3b82f6 12px 24px
-    );
-  background-size:48px 48px;
-  background-position:0 0;
-  animation:stripe 1.2s linear infinite;
+  background: linear-gradient(90deg, #2563eb, #3b82f6);
+  background-size: 200% 100%;
+  background-position: 0 0;
+  animation: shimmer 1.5s linear infinite;
   will-change: background-position;
 }
 /* fertig (grün, keine Animation) */
@@ -90,9 +85,9 @@
   background:#ef4444;
   animation:none;
 }
-  @keyframes stripe{
+  @keyframes shimmer{
     from{ background-position:0 0; }
-    to  { background-position:48px 0; }
+    to  { background-position:-200% 0; }
   }
   @media (prefers-reduced-motion: reduce){
     #map-progress .bar{ animation:none; }
@@ -111,6 +106,11 @@
   .row{padding:6px 0;border-bottom:1px dashed #444}.row:last-child{border-bottom:0}
   .muted{color:#aaa}
   .thumb{width:256px;height:256px;object-fit:cover;border-radius:6px;margin-right:8px;vertical-align:middle}
+
+  /* Popup/Preview Lists */
+  .preview-list{list-style:none;padding:0;margin:6px 0}
+  .preview-list li{position:relative;padding-left:12px;margin:4px 0}
+  .preview-list li::before{content:"";position:absolute;left:0;top:9px;width:4px;height:4px;border-radius:50%;background:var(--accent);}
 
   /* Auf-/zuklappbare Ortsgruppen + Galerie */
   #results .groupbox{border:1px solid var(--border);border-radius:10px;margin:10px 0;overflow:hidden;background:#151515}

--- a/web/route.js
+++ b/web/route.js
@@ -85,20 +85,30 @@ function addResultGalleryGroup(loc, cardHtml){
 // -------- Debounce & Autocomplete (auf DE beschränkt) --------
 function debounce(fn,ms){let t;return(...a)=>{clearTimeout(t);t=setTimeout(()=>fn(...a),ms);};}
 async function geocodeSuggest(q){
-  if(!q||q.length<3) return [];
+  if(!q||q.length<2) return [];
   if(geocodeCache.has(q)) return geocodeCache.get(q);
-  const url=`https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&limit=5&countrycodes=de&q=${encodeURIComponent(q)}`;
+  const url=`https://photon.komoot.io/api/?q=${encodeURIComponent(q)}&limit=5&lang=de&countrycode=DE`;
   const res=await fetch(url,{headers:NOMINATIM_HEADERS});
-  if(!res.ok) throw new Error("Nominatim Suggest HTTP "+res.status);
+  if(!res.ok) throw new Error("Photon Suggest HTTP "+res.status);
   const data=await res.json();
-  geocodeCache.set(q, data);
-  return data;
+  const items=data.features.filter(f=>{const t=f.properties.osm_value;return ["city","town","village","suburb","postcode","district"].includes(t);});
+  geocodeCache.set(q, items);
+  return items;
 }
 function bindSuggest(inputSel,listSel){
   const input=$(inputSel), list=$(listSel);
   const render=items=>{
     if(!items.length){list.hidden=true;list.innerHTML="";return;}
-    list.innerHTML=items.map(i=>`<li data-lat="${Number(i.lat)}" data-lon="${Number(i.lon)}">${escapeHtml(i.display_name)}</li>`).join("");
+    list.innerHTML=items.map(i=>{
+      const lat=Number(i.geometry.coordinates[1]);
+      const lon=Number(i.geometry.coordinates[0]);
+      const p=i.properties;
+      const parts=[p.name];
+      if(p.postcode) parts.push(p.postcode);
+      if(p.city && p.city!==p.name) parts.push(p.city);
+      if(p.country) parts.push(p.country);
+      return `<li data-lat="${lat}" data-lon="${lon}">${escapeHtml(parts.filter(Boolean).join(", "))}</li>`;
+    }).join("");
     list.hidden=false;
   };
   const onPick=li=>{
@@ -138,15 +148,15 @@ function addListingToClusters(lat, lon, itemHtml, titleForPopup="Anzeigen in der
   const existing = markerClusters.find(c => distMeters(c.lat,c.lon,lat,lon) < 200); // 200 m
   if(existing){
     existing.items.push(itemHtml);
-    const list = `<strong>${titleForPopup}</strong><ul style="padding-left:18px;margin:6px 0">
-      ${existing.items.map(x=>`<li style="margin:4px 0">${x}</li>`).join('')}
+    const list = `<strong>${titleForPopup}</strong><ul class="preview-list">
+      ${existing.items.map(x=>`<li>${x}</li>`).join('')}
     </ul>`;
     existing.marker.setPopupContent(list);
     return existing.marker;
   }else{
     const marker = L.marker([lat,lon],{icon:greenIcon}).addTo(resultMarkers);
-    const list = `<strong>${titleForPopup}</strong><ul style="padding-left:18px;margin:6px 0">
-      <li style="margin:4px 0">${itemHtml}</li>
+    const list = `<strong>${titleForPopup}</strong><ul class="preview-list">
+      <li>${itemHtml}</li>
     </ul>`;
     marker.bindPopup(list);
     markerClusters.push({lat,lon,marker,items:[itemHtml]});


### PR DESCRIPTION
## Summary
- Make progress bar animation smooth with gradient shimmer
- Use Photon API for fuzzy location autocomplete incl. postal codes
- Style marker preview lists with subtle dot separators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a84b43066483258baec22b857dd21d