### PR TITLE
Fix autocomplete trigger length

### DIFF
--- a/web/route.js
+++ b/web/route.js
@@ -85,7 +85,9 @@ function addResultGalleryGroup(loc, cardHtml){
 // -------- Debounce & Autocomplete (auf DE beschränkt) --------
 function debounce(fn,ms){let t;return(...a)=>{clearTimeout(t);t=setTimeout(()=>fn(...a),ms);};}
 async function geocodeSuggest(q){
-  if(!q||q.length<3) return [];
+  // Show suggestions as early as possible; Nominatim happily accepts
+  // two-character queries, so we only guard against empty strings.
+  if(!q||q.length<2) return [];
   if(geocodeCache.has(q)) return geocodeCache.get(q);
   const url=`https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&limit=5&countrycodes=de&q=${encodeURIComponent(q)}`;
   const res=await fetch(url,{headers:NOMINATIM_HEADERS});


### PR DESCRIPTION
## Summary
- show location suggestions after typing two characters instead of three

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a852e51e6c83258d00d228b8df85cc