### PR TITLE
style: center desktop layout with dark gray theme

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -1,5 +1,5 @@
   :root{
-    --bg:#121212;--fg:#e0e0e0;--card:#1e1e1e;--border:#333;--accent:#1e66f5;--ok:#43d17c;--err:#ef5350;
+    --bg:#1e1e1e;--fg:#e0e0e0;--card:#2a2a2a;--border:#444;--accent:#1e66f5;--ok:#43d17c;--err:#ef5350;
   }
   *{box-sizing:border-box}
   body{margin:0;font:14px/1.4 system-ui,Segoe UI,Roboto,Arial;background:var(--bg);color:var(--fg)}
@@ -9,6 +9,12 @@
   a, a:visited{color:#b4c7ff;text-decoration:none}
   a:hover{color:#d5e2ff;text-decoration:underline}
   .hidden{display:none!important}
+
+  /* Center content with max width */
+  .app-header, header, #map-box, #panel{
+    max-width:900px;
+    margin:0 auto;
+  }
 
   /* App Header */
   .app-header{
@@ -35,7 +41,7 @@
   }
   header .group{display:flex;flex-direction:column;gap:4px;flex:1;min-width:240px}
   input,button{
-    padding:10px 12px;border:1px solid var(--border);border-radius:10px;font:inherit;background:#0e0e0e;color:var(--fg)
+    padding:10px 12px;border:1px solid var(--border);border-radius:10px;font:inherit;background:var(--card);color:var(--fg)
   }
   input:focus{outline:2px solid #2a6dfb}
   button{cursor:pointer;background:var(--accent);color:#fff;border:none;font-weight:700}
@@ -44,7 +50,7 @@
   .suggest{position:relative}
   .suggest ul{
     position:absolute;left:0;right:0;top:calc(100% + 6px);z-index:999;margin:0;list-style:none;padding:6px;border:1px solid var(--border);
-    background:#0e0e0e;border-radius:10px;max-height:240px;overflow:auto;box-shadow:0 6px 18px rgba(0,0,0,.35)
+    background:var(--card);border-radius:10px;max-height:240px;overflow:auto;box-shadow:0 6px 18px rgba(0,0,0,.35)
   }
   .suggest li{padding:8px 10px;border-radius:8px;cursor:pointer}
   .suggest li:hover{background:#1b1b1b}
@@ -113,7 +119,7 @@
   .preview-list li::before{content:"";position:absolute;left:0;top:9px;width:4px;height:4px;border-radius:50%;background:var(--accent);}
 
   /* Auf-/zuklappbare Ortsgruppen + Galerie */
-  #results .groupbox{border:1px solid var(--border);border-radius:10px;margin:10px 0;overflow:hidden;background:#151515}
+  #results .groupbox{border:1px solid var(--border);border-radius:10px;margin:10px 0;overflow:hidden;background:var(--card)}
   #results .groupbox summary{
     cursor:pointer;padding:10px 12px;font-weight:700;list-style:none;display:flex;justify-content:space-between;align-items:center
   }


### PR DESCRIPTION
## Summary
- limit web interface width on desktop for a centered viewport
- apply dark gray color scheme and update inputs and panels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a8ab5b40c083258fda0fa4a1b3c0b5