### PR TITLE
Rename project to Klanavo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kleinanzeigen Route
+# Klanavo
 
-Durchsucht eBay Kleinanzeigen entlang beliebiger Routen. Ein FastAPI-Backend liefert Inserate und ein leichtes Frontend zeigt sie direkt auf der Karte.
+Klanavo durchsucht eBay Kleinanzeigen entlang beliebiger Routen. Ein FastAPI-Backend liefert Inserate und ein leichtes Frontend zeigt sie direkt auf der Karte.
 
 ## Schnellstart
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,4 @@
-"""API service for :mod:`kleinanzeigen_suite`.
+"""API service for Klanavo.
 
 Previously the application exposed only a health-check endpoint and returned
 an empty payload for ``/inserate``.  This file now wires up the real

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  kleinanzeigen_suite:
+  klanavo:
     build:
       context: .              # <— Projekt-Root als Kontext
       dockerfile: ops/Dockerfile
-    container_name: kleinanzeigen_suite
+    container_name: klanavo
     ports:
       - "8401:80"
     restart: unless-stopped

--- a/web/route.html
+++ b/web/route.html
@@ -2,14 +2,14 @@
 <html lang="de">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Kleinanzeigen Routen-Suche</title>
+<title>Klanavo Routen-Suche</title>
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css">
 <link rel="stylesheet" href="route.css">
 
 <body>
 
 <div class="app-header">
-  <h1>Kleinanzeigen Routensuche</h1>
+  <h1>Klanavo Routensuche</h1>
   <p>Berechne eine Route zwischen Start und Ziel, finde Inserate entlang der Strecke und sieh sie direkt auf der Karte.</p>
 </div>
 


### PR DESCRIPTION
## Summary
- rename project references from "Kleinanzeigen Route" to "Klanavo"
- update service names and documentation to use new project name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a8b0401a8c8325a6060c5a67a56b33