### PR TITLE
Add header search bar, reset flow, and footer

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -11,7 +11,7 @@
   .hidden{display:none!important}
 
   /* Center content with max width */
-  .app-header, header, #map-box, #panel{
+  .app-header, #map-box, #panel, footer{
     max-width:900px;
     margin:0 auto;
   }
@@ -23,6 +23,18 @@
     border-bottom:2px solid var(--accent);
     text-align:center;
   }
+  #search-bar{
+    text-align:left;
+    display:flex;
+    flex-wrap:wrap;
+    gap:10px;
+    padding:12px;
+    background:var(--card);
+    border:1px solid var(--border);
+    border-radius:10px;
+    margin-bottom:20px;
+  }
+  #search-bar .group{display:flex;flex-direction:column;gap:4px;flex:1;min-width:240px}
   .app-header h1{
     margin:0 0 6px;
     font-size:22px;
@@ -35,12 +47,16 @@
     color:#ccc;
   }
 
-  /* Header / Inputs */
-  header{
-    display:flex;flex-wrap:wrap;gap:10px;padding:12px;background:var(--card);
-    border:1px solid var(--border);border-radius:10px
+  /* Footer */
+  footer{
+    margin-top:20px;
+    padding:20px 12px;
+    background:var(--card);
+    border-top:2px solid var(--accent);
+    text-align:center;
+    font-size:14px;
+    color:#ccc;
   }
-  header .group{display:flex;flex-direction:column;gap:4px;flex:1;min-width:240px}
   input,button{
     padding:10px 12px;border:1px solid var(--border);border-radius:10px;font:inherit;background:var(--card);color:var(--fg)
   }
@@ -197,12 +213,12 @@
 
   /* HARD mobile layout */
   @media (max-width: 768px){
-    header{
+    #search-bar{
       display:grid;
       grid-template-columns: 1fr;
       gap:14px;
     }
-    header .group{min-width:100%}
+    #search-bar .group{min-width:100%}
     input,button{font-size:16px;padding:14px}
     #btnRun{width:100%}
     #map{height:45vh}

--- a/web/route.html
+++ b/web/route.html
@@ -8,30 +8,33 @@
 
 <body>
 
-<div class="app-header">
+<header class="app-header">
+  <div id="search-bar">
+    <div class="group suggest" id="grpStart">
+      <label for="start">Start</label>
+      <input id="start" placeholder="Adresse/Ort eingeben" autocomplete="off">
+      <ul id="start-suggest" hidden></ul>
+    </div>
+    <div class="group suggest" id="grpZiel">
+      <label for="ziel">Ziel</label>
+      <input id="ziel" placeholder="Adresse/Ort eingeben" autocomplete="off">
+      <ul id="ziel-suggest" hidden></ul>
+    </div>
+    <div class="group" id="grpQuery">
+      <label for="query">Suchbegriff</label>
+      <input id="query" placeholder="Suchbegriff">
+    </div>
+    <div class="group" id="grpRun">
+      <label>&nbsp;</label>
+      <button id="btnRun">Route berechnen &amp; suchen</button>
+    </div>
+    <div class="group hidden" id="grpReset">
+      <label>&nbsp;</label>
+      <button id="btnReset">Neue Suche</button>
+    </div>
+  </div>
   <h1>Klanavo Routensuche</h1>
   <p>Berechne eine Route zwischen Start und Ziel, finde Inserate entlang der Strecke und sieh sie direkt auf der Karte.</p>
-</div>
-
-<header>
-  <div class="group suggest" id="grpStart">
-    <label for="start">Start</label>
-    <input id="start" placeholder="Adresse/Ort eingeben" autocomplete="off">
-    <ul id="start-suggest" hidden></ul>
-  </div>
-  <div class="group suggest" id="grpZiel">
-    <label for="ziel">Ziel</label>
-    <input id="ziel" placeholder="Adresse/Ort eingeben" autocomplete="off">
-    <ul id="ziel-suggest" hidden></ul>
-  </div>
-  <div class="group" id="grpQuery">
-    <label for="query">Suchbegriff</label>
-    <input id="query" placeholder="Suchbegriff">
-  </div>
-  <div class="group" id="grpRun">
-    <label>&nbsp;</label>
-    <button id="btnRun">Route berechnen &amp; suchen</button>
-  </div>
 </header>
 
 <div id="map-box" class="hidden">
@@ -42,6 +45,10 @@
 <div id="panel">
   <div id="results" class="hidden"><strong>Ergebnisliste</strong></div>
 </div>
+
+<footer>
+  <p>Kontakt: <a id="contact-email"></a> | <a href="https://github.com/klanavo/ka-route" target="_blank" rel="noopener">GitHub</a></p>
+</footer>
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
 <script src="config.js"></script>

--- a/web/route.js
+++ b/web/route.js
@@ -25,7 +25,14 @@ const resultMarkers = L.layerGroup().addTo(map);
 
 // Shorthands
 const $=sel=>document.querySelector(sel);
-const startGroup=$("#grpStart"), zielGroup=$("#grpZiel"), queryGroup=$("#grpQuery"), runGroup=$("#grpRun"), mapBox=$("#map-box");
+const startGroup=$("#grpStart"), zielGroup=$("#grpZiel"), queryGroup=$("#grpQuery"), runGroup=$("#grpRun"), resetGroup=$("#grpReset"), mapBox=$("#map-box");
+
+// set contact email without exposing plain text in HTML
+(function(){
+  const user="klanavo", domain="zneb.to";
+  const el=document.getElementById("contact-email");
+  if(el){ const addr=user+"@"+domain; el.href="mailto:"+addr; el.textContent=addr; }
+})();
 // Progress-Helfer
 function setProgress(pct){
   const bar = $("#progressBar"), txt = $("#progressText");
@@ -64,6 +71,28 @@ function clearResults(){
   resultMarkers.clearLayers();markerClusters.length=0;
   groups.clear();
 }
+
+function resetAll(){
+  running=false;
+  $("#btnRun").textContent="Route berechnen & suchen";
+  startGroup.classList.remove("hidden");
+  zielGroup.classList.remove("hidden");
+  queryGroup.classList.remove("hidden");
+  runGroup.classList.remove("hidden");
+  resetGroup.classList.add("hidden");
+  mapBox.classList.add("hidden");
+  $("#results").classList.add("hidden");
+  clearResults();
+  const s=$("#start"), z=$("#ziel"), q=$("#query");
+  s.value=""; z.value=""; q.value="";
+  delete s.dataset.lat; delete s.dataset.lon;
+  delete z.dataset.lat; delete z.dataset.lon;
+  setProgress(0);
+  setProgressState(null, "0%");
+  if(routeLayer){ map.removeLayer(routeLayer); routeLayer=undefined; }
+}
+
+$("#btnReset").addEventListener("click", resetAll);
 function addResultGalleryGroup(loc, cardHtml){
   const results = $("#results");
   if(results.dataset.cleared!="1"){
@@ -404,6 +433,7 @@ async function fetchApiInserate(q, plz, rKm) {
 // ---------- Start/Stop ----------
 let running=false;
 $("#btnRun").addEventListener("click",()=>{
+  resetGroup.classList.add("hidden");
   if(running){
     running=false;
     setStatus("Suche abgebrochen.", true);
@@ -413,6 +443,7 @@ $("#btnRun").addEventListener("click",()=>{
     zielGroup.classList.remove("hidden");
     queryGroup.classList.remove("hidden");
     mapBox.classList.add("hidden");
+    runGroup.classList.remove("hidden");
   } else {
     run();
   }
@@ -571,6 +602,7 @@ catch(e){
   setProgress(100);
   setProgressState("done", `Fertig – ${totalFound} Inserate`);
   runGroup.classList.add("hidden");
+  resetGroup.classList.remove("hidden");
 }catch(e){
   setStatus(e.message,true);
   setProgressState("aborted","Abgebrochen");
@@ -578,6 +610,8 @@ catch(e){
   zielGroup.classList.remove("hidden");
   queryGroup.classList.remove("hidden");
   mapBox.classList.add("hidden");
+  runGroup.classList.remove("hidden");
+  resetGroup.classList.add("hidden");
 }
 running=false; $("#btnRun").textContent="Route berechnen & suchen";
 }


### PR DESCRIPTION
## Summary
- Move route search inputs into header and add restart button for new queries
- Add footer with contact email and GitHub repository link
- Obfuscate email via JavaScript to reduce crawler exposure

## Testing
- `node --check web/route.js`
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68a8b2a5108883259054eea1ede98c89