### PR TITLE
Refine branding and controls for klanavo

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -28,6 +28,13 @@
     font-size:22px;
     font-weight:800;
     color:#fff;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    gap:10px;
+  }
+  .app-header h1 img{
+    height:40px;
   }
   .app-header p{
     margin:0;
@@ -109,7 +116,9 @@
   /* Panel + Gruppen-Boxen */
   #panel{display:flex;flex-direction:column;gap:10px;padding:12px}
   #results{border:1px solid var(--border);border-radius:10px;padding:12px;background:var(--card)}
-  #results strong{display:block;margin-bottom:6px}
+  #results .results-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px}
+  #results strong{margin:0}
+  #results .toggle-all{background:none;border:none;color:var(--fg);cursor:pointer;font-size:14px}
   .row{padding:6px 0;border-bottom:1px dashed #444}.row:last-child{border-bottom:0}
   .muted{color:#aaa}
   .thumb{width:256px;height:256px;object-fit:cover;border-radius:6px;margin-right:8px;vertical-align:middle}

--- a/web/route.html
+++ b/web/route.html
@@ -2,15 +2,16 @@
 <html lang="de">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Klanavo Routen-Suche</title>
+<title>klanavo</title>
+<link rel="icon" type="image/png" href="favico.png">
 <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css">
 <link rel="stylesheet" href="route.css">
 
 <body>
 
 <div class="app-header">
-  <h1>Klanavo Routensuche</h1>
-  <p>Berechne eine Route zwischen Start und Ziel, finde Inserate entlang der Strecke und sieh sie direkt auf der Karte.</p>
+  <h1><img src="klanavo.png" alt="klanavo" class="logo"> klanavo</h1>
+  <p>Plane deine Route von Start bis Ziel, entdecke Inserate entlang der Strecke und klick dich durch die grünen Pins auf der Karte. Bei Problemen schreib uns an klanavo[at]zneb.to.</p>
 </div>
 
 <header>
@@ -32,6 +33,10 @@
     <label>&nbsp;</label>
     <button id="btnRun">Route berechnen &amp; suchen</button>
   </div>
+  <div class="group hidden" id="grpReset">
+    <label>&nbsp;</label>
+    <button id="btnReset">Neustart</button>
+  </div>
 </header>
 
 <div id="map-box" class="hidden">
@@ -40,7 +45,7 @@
 </div>
 
 <div id="panel">
-  <div id="results" class="hidden"><strong>Ergebnisliste</strong></div>
+  <div id="results" class="hidden"><div class="results-header"><strong>Ergebnisliste</strong><button id="btnToggleAll" class="toggle-all" data-state="closed" title="Alle ausklappen">▼</button></div></div>
 </div>
 
 <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- use klanavo logo and favicon, simplify titles
- refresh intro text and add contact notice
- add expand/collapse for results and reset button after search

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a8b70999cc8325b1159bd7da54bdb9