### PR TITLE
Add optional ORS API key setting and rate limit display

### DIFF
--- a/web/route.html
+++ b/web/route.html
@@ -46,6 +46,9 @@
         <option value="1" label="10"></option>
         <option value="2" label="20"></option>
       </datalist>
+      <label for="apiKey">Eigener ORS API-Key (optional, <a href="https://openrouteservice.org/dev/#/signup" target="_blank">hier</a>)</label>
+      <input id="apiKey" type="password" placeholder="API-Key">
+      <div id="rateLimitInfo" class="muted"></div>
     </details>
   </div>
   <div class="group" id="grpRun">


### PR DESCRIPTION
## Summary
- allow entering custom ORS API key with link to signup
- show API rate limits for the active ORS key in settings

## Testing
- `node --check web/route.js`
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_68a95e7874b08325ba5f54de29251f86