### PR TITLE
Replace failing Nginx proxy with FastAPI service

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 playwright
 python-multipart
+httpx

--- a/ops/nginx.conf
+++ b/ops/nginx.conf
@@ -70,35 +70,22 @@ location /api/ {
     proxy_read_timeout       60s;
     proxy_send_timeout       60s;
 }
-        # -------- PROXY -> externe Seiten (z.B. kleinanzeigen.de) --------
-        resolver 1.1.1.1 1.0.0.1 valid=30s ipv6=off;
-
+        # -------- PROXY -> FastAPI backend --------
         location /proxy {
-            set $target $arg_u;
-            if ($target = "") { return 400 "missing u"; }
-
             add_header Access-Control-Allow-Origin * always;
             add_header Access-Control-Allow-Headers * always;
             add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
             add_header Access-Control-Expose-Headers * always;
-
-            # Browser-ähnliche Header
-            proxy_set_header User-Agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36";
-            proxy_set_header Accept "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
-            proxy_set_header Accept-Language "de-DE,de;q=0.9";
-            proxy_set_header Referer "https://www.kleinanzeigen.de/";
-            proxy_set_header Cache-Control "no-cache";
-
-            # Komprimierung deaktivieren, damit wir sauber parsen können
-            proxy_set_header Accept-Encoding "";
-
-            proxy_ssl_server_name on;
-            proxy_pass $target;
-
-            # WICHTIG: HTML-Content-Type setzen (kein .bin Download auf Mobile)
-            default_type text/html;
-
             if ($request_method = OPTIONS) { return 204; }
+
+            proxy_pass http://127.0.0.1:8000;
+            proxy_http_version 1.1;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_buffering          off;
+            proxy_request_buffering  off;
         }
 
         # -------- Static (optional) --------


### PR DESCRIPTION
## Summary
- add FastAPI `/proxy` endpoint that fetches external resources using httpx
- forward `/proxy` requests through Nginx to the backend service
- include httpx in API requirements

## Testing
- `pip install -r api/requirements.txt`
- `python -m py_compile api/main.py`
- `node --check web/route.js`


------
https://chatgpt.com/codex/tasks/task_b_68a9b70bd9fc83259f2dbd4da2d96e0b