### PR TITLE
Handle listings missing coordinates

### DIFF
--- a/web/route.js
+++ b/web/route.js
@@ -733,10 +733,6 @@ catch(e){
         results.forEach((res,idx)=>{
           if(res.status!=="fulfilled") return;
           const enrich=res.value;
-          if(!enrich.lat||!enrich.lon) return;
-          const minDist=routeIdx.distance(enrich.lat,enrich.lon);
-          if(minDist>10000) return;
-          totalFound++;
           const it=chunk[idx];
           const loc=enrich.label||plz||"?";
           const price=enrich.price;
@@ -751,8 +747,14 @@ catch(e){
           <div class="muted">${escapeHtml(infoLine)}</div>
         `;
           addResultGalleryGroup(loc, cardHtml);
-          const popupHtml=`<a href="${escapeHtml(it.url)}" target="_blank"><strong>${escapeHtml(it.title)}</strong></a><br>${escapeHtml(price)}${catName?`<br>${escapeHtml(catName)}`:''}<br>${escapeHtml(loc)}${enrich.image?`<br><img src="${escapeHtml(enrich.image)}" style="max-width:180px;border-radius:8px">`:''}`;
-          addListingToClusters(enrich.lat,enrich.lon,popupHtml,"Anzeigen in der Nähe");
+          if(enrich.lat&&enrich.lon){
+            const minDist=routeIdx.distance(enrich.lat,enrich.lon);
+            if(minDist<=10000){
+              totalFound++;
+              const popupHtml=`<a href="${escapeHtml(it.url)}" target="_blank"><strong>${escapeHtml(it.title)}</strong></a><br>${escapeHtml(price)}${catName?`<br>${escapeHtml(catName)}`:''}<br>${escapeHtml(loc)}${enrich.image?`<br><img src="${escapeHtml(enrich.image)}" style="max-width:180px;border-radius:8px">`:''}`;
+              addListingToClusters(enrich.lat,enrich.lon,popupHtml,"Anzeigen in der Nähe");
+            }
+          }
         });
       }
 


### PR DESCRIPTION
## Summary
- Display results in list even when geocoding fails
- Only add map markers for listings with valid coordinates

## Testing
- `node --check web/route.js`


------
https://chatgpt.com/codex/tasks/task_b_68a9b8b926ec8325a7706e52a7d42862