### PR TITLE
Improve location resolution and keep map when search aborted

### DIFF
--- a/web/route.js
+++ b/web/route.js
@@ -467,7 +467,9 @@ async function reversePLZ(postal){
           const lat=f.geometry.coordinates[1], lon=f.geometry.coordinates[0];
           const props=f.properties||{};
           const city=props.locality||props.region||props.name||"";
-          return {lat,lon,display:`${postal}${city?` ${city}`:""}`};
+          if(city && !/deutschland/i.test(city)){
+            return {lat,lon,display:`${postal}${city?` ${city}`:""}`};
+          }
         }
       }
     }
@@ -590,7 +592,6 @@ $("#btnRun").addEventListener("click",()=>{
     categoryGroup.classList.remove("hidden");
     priceGroup.classList.remove("hidden");
     settingsGroup.classList.remove("hidden");
-    mapBox.classList.add("hidden");
   } else {
     run();
   }


### PR DESCRIPTION
## Summary
- Fall back to Nominatim when reverse geocoding returns only `Deutschland`
- Keep map and existing pins visible when stopping an ongoing search

## Testing
- `node --check web/route.js`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9bcaaf6088325b6344f173da0a81a