### PR TITLE
Proxy ORS requests through Nginx

### DIFF
--- a/ops/nginx.conf
+++ b/ops/nginx.conf
@@ -88,6 +88,24 @@ location /api/ {
             proxy_request_buffering  off;
         }
 
+        # -------- ORS API proxy --------
+        location /ors/ {
+            add_header Access-Control-Allow-Origin * always;
+            add_header Access-Control-Allow-Headers * always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+            add_header Access-Control-Expose-Headers * always;
+            if ($request_method = OPTIONS) { return 204; }
+
+            proxy_pass http://127.0.0.1:8000;
+            proxy_http_version 1.1;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_buffering          off;
+            proxy_request_buffering  off;
+        }
+
         # -------- Static (optional) --------
         location / {
             add_header Access-Control-Allow-Origin * always;


### PR DESCRIPTION
## Summary
- proxy /ors/ paths in nginx to the FastAPI backend so OpenRouteService requests succeed

## Testing
- `python -m py_compile api/main.py`
- `nginx -t -c ops/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9c97016208325a99fcf9117f86351