### PR TITLE
Fix route search API path

### DIFF
--- a/web/route.js
+++ b/web/route.js
@@ -535,7 +535,7 @@ async function run(){
   stepKm = stepOptions[Number(stepInput.value)] || stepKm;
 
   try{
-    const resp=await fetch('/route-search',{
+    const resp=await fetch('/api/route-search',{
       method:'POST',
       headers:{'Content-Type':'application/json'},
       body:JSON.stringify({start:startText, ziel:zielText, query:q, radius:rKm, step:stepKm, min_price:minPrice, max_price:maxPrice}),


### PR DESCRIPTION
## Summary
- ensure frontend calls /api/route-search to match backend routing

## Testing
- `node --check web/route.js`
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68aabebdb1f08325a094802f8c187d30