### PR TITLE
Remove unused clear button and improve error handling

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -230,6 +230,7 @@ async def _reverse_plz(client: httpx.AsyncClient, api_key: str, lat: float, lon:
 
 
 @app.post("/route-search")
+@app.post("/api/route-search")
 async def route_search(req: RouteSearchRequest) -> dict:
     if browser_manager is None:  # pragma: no cover - should not happen
         raise HTTPException(status_code=503, detail="Browser not initialised")

--- a/web/route.html
+++ b/web/route.html
@@ -75,7 +75,6 @@
   <div class="group hidden" id="grpReset">
     <label>&nbsp;</label>
     <button id="btnReset">Neustart</button>
-    <button id="btnClear">Felder leeren</button>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- remove redundant "Felder leeren" reset button from UI
- validate start and destination before running and surface API error details
- expose route search endpoint also under `/api/route-search`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aac0176b30832595fe8f9940af0066