### PR TITLE
Add optional location grouping for gallery

### DIFF
--- a/web/route.css
+++ b/web/route.css
@@ -137,12 +137,11 @@
   /* Panel + Gruppen-Boxen */
   #panel{display:flex;flex-direction:column;gap:10px;padding:12px}
   #results{border:1px solid var(--border);border-radius:10px;padding:12px;background:var(--card)}
-  #results .results-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px}
+  #results .results-header{display:flex;justify-content:flex-start;align-items:center;margin-bottom:6px}
   #resultsControls{display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px}
   #resultsControls .price-range input{width:80px}
   #resultsControls .sort-icons button{background:none;border:1px solid var(--border);border-radius:6px;padding:4px 6px;cursor:pointer}
   #results strong{margin:0}
-  #results .toggle-all{background:none;border:none;color:var(--fg);cursor:pointer;font-size:14px}
   .row{padding:6px 0;border-bottom:1px dashed #444}.row:last-child{border-bottom:0}
   .muted{color:#aaa}
   .thumb{width:256px;height:256px;object-fit:cover;border-radius:6px;margin-right:8px;vertical-align:middle}

--- a/web/route.html
+++ b/web/route.html
@@ -78,17 +78,18 @@
 
 <div id="panel">
   <div id="results" class="hidden">
-    <div class="results-header"><strong>Ergebnisliste</strong><button id="btnToggleAll" class="toggle-all" data-state="closed" title="Alle ausklappen">▼</button></div>
+    <div class="results-header"><strong>Ergebnisliste</strong></div>
     <div id="resultsControls">
       <div class="price-range">
         <input id="filterPriceMin" type="number" placeholder="Preis von">
         <input id="filterPriceMax" type="number" placeholder="bis">
       </div>
       <div class="sort-icons">
-        <button id="sortLocation" data-dir="asc" title="Nach Ort sortieren">📍</button>
+        <button id="toggleGrouping" title="Nach Ort gruppieren">📍</button>
         <button id="sortPrice" data-dir="asc" title="Nach Preis sortieren">€</button>
       </div>
     </div>
+    <div id="resultGallery" class="gallery"></div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Add a toggle icon to group search results by location
- Show all results in a single gallery by default
- Remove location sorting and global expand/collapse controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68aace5dd4e88325bf41bf5b224e2b1a