### PR TITLE
Add category support and robust price parsing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -94,6 +94,7 @@ async def inserate(
     radius: int = 10,
     min_price: Optional[int] = None,
     max_price: Optional[int] = None,
+    category: Optional[int] = None,
     page_count: int = 1,
 ) -> dict[str, list]:
     """Return classifieds scraped from eBay Kleinanzeigen.
@@ -136,6 +137,8 @@ async def inserate(
             kwargs["min_price"] = min_price
         if "max_price" in params and max_price is not None:
             kwargs["max_price"] = max_price
+        if "category_id" in params and category is not None:
+            kwargs["category_id"] = category
         if "page_count" in params:
             kwargs["page_count"] = page_count
 
@@ -154,6 +157,7 @@ class RouteSearchRequest(BaseModel):
     query: Optional[str] = None
     min_price: Optional[int] = None
     max_price: Optional[int] = None
+    category: Optional[int] = None
 
 
 async def _geocode_text(client: httpx.AsyncClient, api_key: str, text: str) -> tuple[float, float]:
@@ -293,6 +297,7 @@ async def route_search(req: RouteSearchRequest) -> dict:
                     radius=req.radius,
                     min_price=req.min_price,
                     max_price=req.max_price,
+                    category_id=req.category,
                 )
             except Exception:
                 continue

--- a/web/route.css
+++ b/web/route.css
@@ -51,8 +51,6 @@
     border:1px solid var(--border);border-radius:10px
   }
   header .group{display:flex;flex-direction:column;gap:4px;flex:1;min-width:240px}
-  header .group .price-range{display:flex;gap:4px}
-  header .group .price-range input{flex:1}
   #grpSettings,#grpRun{flex:1 1 100%}
   #grpSettings details{display:flex;flex-direction:column;gap:4px;width:100%}
   #grpSettings summary{cursor:pointer;list-style:none;display:flex;align-items:center;gap:4px;font-weight:700}
@@ -139,7 +137,10 @@
   #results{border:1px solid var(--border);border-radius:10px;padding:12px;background:var(--card)}
   #results .results-header{display:flex;justify-content:flex-start;align-items:center;margin-bottom:6px}
   #resultsControls{display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px}
-  #resultsControls .price-range input{width:80px}
+  #resultsControls .price-range{display:flex;flex-direction:column;gap:4px}
+  #resultsControls .price-range .range-inputs{display:flex;gap:4px}
+  #resultsControls .price-range .range-inputs input{flex:1}
+  #resultsControls .price-range label{font-size:12px}
   #resultsControls .sort-icons button{background:none;border:1px solid var(--border);border-radius:6px;padding:4px 6px;cursor:pointer}
   #results strong{margin:0}
   .row{padding:6px 0;border-bottom:1px dashed #444}.row:last-child{border-bottom:0}

--- a/web/route.html
+++ b/web/route.html
@@ -33,14 +33,12 @@
   </div>
   <div class="group" id="grpQuery">
     <label for="query">Suchbegriff</label>
-    <input id="query" placeholder="Suchbegriff">
+    <input id="query" placeholder="Suchbegriff" required>
   </div>
-  <!-- Kategorien vorerst deaktiviert
   <div class="group" id="grpCategory">
     <label for="category">Kategorie</label>
     <select id="category"></select>
   </div>
-  -->
   <div class="group" id="grpSettings">
     <details>
       <summary>⚙ Einstellungen</summary>
@@ -81,8 +79,11 @@
     <div class="results-header"><strong>Ergebnisliste</strong></div>
     <div id="resultsControls">
       <div class="price-range">
-        <input id="filterPriceMin" type="number" placeholder="Preis von">
-        <input id="filterPriceMax" type="number" placeholder="bis">
+        <label for="filterPriceMin">Preisfilter</label>
+        <div class="range-inputs">
+          <input id="filterPriceMin" type="text" placeholder="von">
+          <input id="filterPriceMax" type="text" placeholder="bis">
+        </div>
       </div>
       <div class="sort-icons">
         <button id="toggleGrouping" title="Nach Ort gruppieren">📍</button>


### PR DESCRIPTION
## Summary
- Require search term and enable category selection
- Show listing categories, allow grouping by location or category
- Fix price parsing, sorting and filtering; format price inputs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aad14340ec8325ab32136d024cbdfd