### PR TITLE
Add footer analytics and disable settings panel

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,7 @@ import asyncio
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
 import math
 
 from pydantic import BaseModel
@@ -50,6 +50,13 @@ _rate_lock = asyncio.Lock()
 
 # Global cache for reverse geocoded postal codes
 _plz_cache: dict[str, str | None] = {}
+
+# Simple in-memory analytics counters
+_stats: dict[str, Any] = {
+    "searches_saved": 0,
+    "listings_found": 0,
+    "visitors": set(),
+}
 
 
 @app.middleware("http")
@@ -260,7 +267,7 @@ async def _reverse_plz(client: httpx.AsyncClient, api_key: str, lat: float, lon:
 
 @app.post("/route-search")
 @app.post("/api/route-search")
-async def route_search(req: RouteSearchRequest) -> dict:
+async def route_search(req: RouteSearchRequest, request: Request) -> dict:
     if browser_manager is None:  # pragma: no cover - should not happen
         raise HTTPException(status_code=503, detail="Browser not initialised")
     api_key = os.getenv("ORS_API_KEY")
@@ -309,7 +316,22 @@ async def route_search(req: RouteSearchRequest) -> dict:
                 it["plz"] = plz
                 results.append(it)
 
+    _stats["searches_saved"] += 1
+    _stats["listings_found"] += len(results)
+    if request.client:
+        _stats["visitors"].add(request.client.host)
+
     return {"route": coords, "listings": results}
+
+
+@app.get("/stats")
+@app.get("/api/stats")
+def stats() -> dict[str, int]:
+    return {
+        "searches_saved": _stats["searches_saved"],
+        "listings_found": _stats["listings_found"],
+        "visitors": len(_stats["visitors"]),
+    }
 
 
 @app.get("/proxy")

--- a/web/route.css
+++ b/web/route.css
@@ -236,6 +236,7 @@
   .leaflet-popup-content::-webkit-scrollbar-thumb:hover{background:#3a3a3a}
   .leaflet-popup-content{ scrollbar-width: thin; scrollbar-color: #2a2a2a #0c0c0c; }
 
+  .analytics{max-width:900px;margin:0 auto 6px;text-align:center;font-size:12px}
   .app-footer{max-width:900px;margin:20px auto;display:flex;gap:10px;justify-content:center;color:var(--fg)}
   .app-footer a{color:var(--fg)}
 

--- a/web/route.html
+++ b/web/route.html
@@ -42,22 +42,23 @@
   </div>
   <div class="group" id="grpSettings">
     <details>
-      <summary><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="icon"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"></path><circle cx="12" cy="12" r="3"></circle></svg> Einstellungen</summary>
-      <label for="radius" title="Umkreis der Suche">Suchradius: <span id="radiusVal"></span> km</label>
-      <input id="radius" type="range" min="0" max="2" step="1" value="1" list="radiusTicks" title="Umkreis der Suche">
-      <datalist id="radiusTicks">
-        <option value="0" label="5"></option>
-        <option value="1" label="10"></option>
-        <option value="2" label="20"></option>
-      </datalist>
-      <label for="step" title="Abstand zwischen Wegpunkten">Punktabstand: <span id="stepVal"></span> km</label>
-      <input id="step" type="range" min="0" max="2" step="1" value="1" list="stepTicks" title="Abstand zwischen Wegpunkten">
-      <datalist id="stepTicks">
-        <option value="0" label="5"></option>
-        <option value="1" label="10"></option>
-        <option value="2" label="20"></option>
-      </datalist>
-      <div id="rateLimitInfo" class="muted"></div>
+      <summary><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="icon"><path d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"></path><circle cx="12" cy="12" r="3"></circle></svg> Einstellungen <span class="muted">– coming soon</span></summary>
+      <div class="hidden">
+        <label for="radius" title="Umkreis der Suche">Suchradius: <span id="radiusVal"></span> km</label>
+        <input id="radius" type="range" min="0" max="2" step="1" value="1" list="radiusTicks" title="Umkreis der Suche">
+        <datalist id="radiusTicks">
+          <option value="0" label="5"></option>
+          <option value="1" label="10"></option>
+          <option value="2" label="20"></option>
+        </datalist>
+        <label for="step" title="Abstand zwischen Wegpunkten">Punktabstand: <span id="stepVal"></span> km</label>
+        <input id="step" type="range" min="0" max="2" step="1" value="1" list="stepTicks" title="Abstand zwischen Wegpunkten">
+        <datalist id="stepTicks">
+          <option value="0" label="5"></option>
+          <option value="1" label="10"></option>
+          <option value="2" label="20"></option>
+        </datalist>
+      </div>
     </details>
   </div>
   <div class="group" id="grpRun">
@@ -99,6 +100,8 @@
 </div>
 
 </div> <!-- end app -->
+
+<div id="analytics" class="analytics muted"></div>
 
 <footer class="app-footer">
   <a href="https://github.com/92thms/ka-route" target="_blank" rel="noopener" title="GitHub">


### PR DESCRIPTION
## Summary
- Display backend stats and API rate limits in a new footer analytics section
- Hide adjustable settings and show an "Einstellungen – coming soon" placeholder with 10 km defaults
- Track searches, listings, and visitors via new `/api/stats` endpoint

## Testing
- `python -m py_compile api/main.py`
- `node --check web/route.js`


------
https://chatgpt.com/codex/tasks/task_b_68aae69ae1048325bb8fd69253d48c4c