### PR TITLE
Persist analytics and rename footer label

### DIFF
--- a/web/route.js
+++ b/web/route.js
@@ -85,7 +85,7 @@ async function fetchRateLimits(){
       ]);
       const parts=[];
       if(stats.searches_saved!=null) parts.push(`eingesparte Suchen: ${stats.searches_saved}`);
-      if(stats.listings_found!=null) parts.push(`Inserate: ${stats.listings_found}`);
+      if(stats.listings_found!=null) parts.push(`gecrawlte Inserate: ${stats.listings_found}`);
       if(stats.visitors!=null) parts.push(`Besucher: ${stats.visitors}`);
       if(limits.geocode&&limits.geocode.limit&&limits.geocode.remaining&&limits.directions&&limits.directions.limit&&limits.directions.remaining){
         parts.push(`API-Limits Geocode ${limits.geocode.remaining}/${limits.geocode.limit}, Directions ${limits.directions.remaining}/${limits.directions.limit}`);


### PR DESCRIPTION
## Summary
- Persist hashed visitor analytics to disk so counts survive restarts
- Rename footer stats label to 'gecrawlte Inserate:'

## Testing
- `python -m py_compile api/main.py`
- `node --check web/route.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aae9d4c6c48325896833777873e47e