### PR TITLE
Improve price filter responsiveness and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # Klanavo
 
-Klanavo durchsucht eBay Kleinanzeigen entlang beliebiger Routen. Ein FastAPI-Backend liefert Inserate und ein leichtes Frontend zeigt sie direkt auf der Karte.
+Klanavo durchsucht eBay Kleinanzeigen entlang beliebiger Routen und zeigt die Treffer direkt auf einer Karte.
+
+## Funktionen
+- Routenplanung und Anzeige der Inserate auf einer Karte
+- Preisfilter, Gruppierung und Sortierung der Ergebnisse
+- Responsives Webfrontend
 
 ## Schnellstart
-
-1. `cp .env.example .env` und den eigenen ORS_API_KEY eintragen (der Schlüssel bleibt auf dem Server und wird nicht im Frontend verwendet). Für Reverse-Geocoding wird standardmäßig Nominatim genutzt; wer einen passenden ORS-Zugang hat, kann in der `.env` zusätzlich `USE_ORS_REVERSE=1` setzen.
+1. `cp .env.example .env` und eigenen `ORS_API_KEY` eintragen. Optional `USE_ORS_REVERSE=1` setzen.
 2. `docker-compose up --build`
 
-Der optionale Parameter USE_ORS_REVERSE lässt sich in `.env` anpassen. Suchradius und Punktabstand werden direkt im UI eingestellt.
+Das Frontend steht anschließend unter [http://localhost:8401](http://localhost:8401) bereit. Suchradius und Punktabstand werden im UI eingestellt. Ein Wartungsmodus lässt sich über `MAINTENANCE_MODE=1` und einen passenden `MAINTENANCE_KEY` aktivieren.
 
-Um einen Wartungsmodus zu aktivieren, können `MAINTENANCE_MODE=1` und ein passender `MAINTENANCE_KEY` in der `.env` gesetzt werden. Ohne gültigen Schlüssel zeigt die Anwendung nur einen Hinweis auf Wartungsarbeiten.
+## Entwicklung
+Backend und Frontend liegen unter `api/` bzw. `web/`. Das Backend basiert auf FastAPI und nutzt Playwright zum Scrapen. Die Weboberfläche ist statisch und benötigt keinen zusätzlichen Build-Schritt.
 
-Das Frontend steht anschließend unter http://localhost:8401 bereit.
+## Danksagung
+Die Ermittlung der Inserate baut auf der großartigen Arbeit der [ebay-kleinanzeigen-api](https://github.com/DanielWTE/ebay-kleinanzeigen-api) auf. Vielen Dank an die Entwickler des Projekts.
 
-## Bedienung
-
-Während der Suche kann über den Button **Abbrechen** der Vorgang sofort gestoppt werden. Bereits gefundene Ergebnisse bleiben erhalten. Mit **Neustart** wird die Anwendung komplett zurückgesetzt und alle Eingabefelder geleert.
-
-Der Quellcode befindet sich auf GitHub unter https://github.com/92thms/ka-route.
+## Lizenz
+[MIT](LICENSE)

--- a/api/main.py
+++ b/api/main.py
@@ -1,10 +1,4 @@
-"""API service for Klanavo.
-
-Previously the application exposed only a health-check endpoint and returned
-an empty payload for ``/inserate``.  This file now wires up the real
-``ebay-kleinanzeigen-api`` scraper so that search queries return actual
-classified ads instead of a static placeholder.
-"""
+"""API service for Klanavo."""
 
 from __future__ import annotations
 
@@ -26,9 +20,7 @@ from fastapi import FastAPI, HTTPException, Request, Response
 import httpx
 
 
-# Make the vendored ``ebay-kleinanzeigen-api`` package importable.  The project
-# lives under ``api/ebay-kleinanzeigen-api`` within this repository, so we add
-# that directory to ``sys.path``.
+# Add the local Kleinanzeigen scraper to the import path
 SCRAPER_DIR = Path(__file__).resolve().parent / "ebay-kleinanzeigen-api"
 sys.path.insert(0, str(SCRAPER_DIR))
 

--- a/web/route.css
+++ b/web/route.css
@@ -139,9 +139,9 @@
   #results{border:1px solid var(--border);border-radius:10px;padding:12px;background:var(--card)}
   #results .results-header{display:flex;justify-content:flex-start;align-items:center;margin-bottom:6px}
   #resultsControls{display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px}
-  #resultsControls .price-range{display:flex;flex-direction:column;gap:4px}
-  #resultsControls .price-range .range-inputs{display:flex;gap:4px}
-  #resultsControls .price-range .range-inputs input{flex:1}
+  #resultsControls .price-range{display:flex;flex-direction:column;gap:4px;flex:1 1 180px}
+  #resultsControls .price-range .range-inputs{display:flex;gap:4px;flex-wrap:wrap}
+  #resultsControls .price-range .range-inputs input{flex:1 1 100px;min-width:0}
   #resultsControls .price-range label{font-size:12px}
   #resultsControls .sort-icons{display:flex;flex-direction:column;align-items:flex-end;gap:4px}
   #resultsControls .sort-icons .icon-buttons{display:flex;gap:4px}

--- a/web/route.js
+++ b/web/route.js
@@ -84,7 +84,7 @@ async function fetchRateLimits(){
         fetchRateLimits()
       ]);
       const parts=[];
-      if(stats.searches_saved!=null) parts.push(`eingesparte Suchen: ${stats.searches_saved}`);
+      if(stats.searches_saved!=null) parts.push(`gestartete Suchen: ${stats.searches_saved}`);
       if(stats.listings_found!=null) parts.push(`gecrawlte Inserate: ${stats.listings_found}`);
       if(stats.visitors!=null) parts.push(`Besucher: ${stats.visitors}`);
       if(limits.geocode&&limits.geocode.limit&&limits.geocode.remaining&&limits.directions&&limits.directions.limit&&limits.directions.remaining){


### PR DESCRIPTION
## Summary
- make price filter inputs responsive in results list
- rename analytics footer counter to "gestartete Suchen"
- remove ebay-kleinanzeigen references from code comments and credit upstream API in README

## Testing
- `node --check web/route.js`
- `python -m py_compile api/main.py`


------
https://chatgpt.com/codex/tasks/task_b_68aaec6b7dac832583f8b669c0da20f3