### PR TITLE
Persist stats across rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Klanavo durchsucht eBay Kleinanzeigen entlang beliebiger Routen und zeigt die Tr
 1. `cp .env.example .env` und eigenen `ORS_API_KEY` eintragen. Optional `USE_ORS_REVERSE=1` setzen.
 2. `docker-compose up --build`
 
+Nutzungsstatistiken werden in `data/stats.json` gespeichert. Das Verzeichnis
+ist als Volume eingebunden, sodass die Werte auch nach einem Update erhalten
+bleiben. IP-Adressen werden dabei gehasht.
+
 Das Frontend steht anschließend unter [http://localhost:8401](http://localhost:8401) bereit. Suchradius und Punktabstand werden im UI eingestellt. Ein Wartungsmodus lässt sich über `MAINTENANCE_MODE=1` und einen passenden `MAINTENANCE_KEY` aktivieren.
 
 ## Entwicklung

--- a/api/main.py
+++ b/api/main.py
@@ -45,8 +45,8 @@ _rate_lock = asyncio.Lock()
 # Global cache for reverse geocoded postal codes
 _plz_cache: dict[str, str | None] = {}
 
-# Simple analytics storage
-_STATS_FILE = Path(__file__).with_name("stats.json")
+# Simple analytics storage; allow custom path via env variable
+_STATS_FILE = Path(os.environ.get("STATS_FILE", "/data/stats.json"))
 
 
 def _load_stats() -> dict[str, Any]:
@@ -70,6 +70,7 @@ def _persist_stats() -> None:
         "visitors": list(_stats.get("visitors", set())),
     }
     try:
+        _STATS_FILE.parent.mkdir(parents=True, exist_ok=True)
         _STATS_FILE.write_text(json.dumps(data))
     except Exception:
         pass

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,5 @@ services:
       MAINTENANCE_MODE: ${MAINTENANCE_MODE:-0}
       MAINTENANCE_KEY: ${MAINTENANCE_KEY:-}
       USE_ORS_REVERSE: ${USE_ORS_REVERSE:-0}
+    volumes:
+      - ./data:/data


### PR DESCRIPTION
## Summary
- persist stats in `/data/stats.json` configurable via `STATS_FILE`
- mount persistent volume for stats in docker-compose
- document stats persistence

## Testing
- `python -m py_compile api/main.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aaed884a108325b694c712d744295d