### PR TITLE
Track unique visitors in stats

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -359,7 +359,10 @@ async def route_search(req: RouteSearchRequest, request: Request) -> dict:
 
 @app.get("/stats")
 @app.get("/api/stats")
-def stats() -> dict[str, int]:
+def stats(request: Request) -> dict[str, int]:
+    if request.client:
+        _stats["visitors"].add(_anonymise_ip(request.client.host))
+        _persist_stats()
     return {
         "searches_saved": _stats["searches_saved"],
         "listings_found": _stats["listings_found"],

--- a/web/route.js
+++ b/web/route.js
@@ -86,7 +86,7 @@ async function fetchRateLimits(){
       const parts=[];
       if(stats.searches_saved!=null) parts.push(`gestartete Suchen: ${stats.searches_saved}`);
       if(stats.listings_found!=null) parts.push(`gecrawlte Inserate: ${stats.listings_found}`);
-      if(stats.visitors!=null) parts.push(`Besucher: ${stats.visitors}`);
+      if(stats.visitors!=null) parts.push(`Besucher gesamt: ${stats.visitors}`);
       if(limits.geocode&&limits.geocode.limit&&limits.geocode.remaining&&limits.directions&&limits.directions.limit&&limits.directions.remaining){
         parts.push(`API-Limits Geocode ${limits.geocode.remaining}/${limits.geocode.limit}, Directions ${limits.directions.remaining}/${limits.directions.limit}`);
       }


### PR DESCRIPTION
## Summary
- Count unique visitors by IP when requesting stats
- Display total visitor count in footer as "Besucher gesamt"

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aaf84e9a04832587a7f299b12141dd