### PR TITLE
Use forwarded IP for unique visitor tracking

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -91,6 +91,16 @@ def _anonymise_ip(ip: str) -> str:
     return hashlib.sha256(ip.encode("utf-8")).hexdigest()
 
 
+def _get_client_ip(request: Request) -> str | None:
+    """Extract client IP from ``X-Forwarded-For`` header or request object."""
+    fwd = request.headers.get("X-Forwarded-For")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return None
+
+
 @app.middleware("http")
 async def _rate_limit(request: Request, call_next) -> Response:
     """Delay requests so that at most one is handled per second."""
@@ -350,8 +360,9 @@ async def route_search(req: RouteSearchRequest, request: Request) -> dict:
 
     _stats["searches_saved"] += 1
     _stats["listings_found"] += len(results)
-    if request.client:
-        _stats["visitors"].add(_anonymise_ip(request.client.host))
+    client_ip = _get_client_ip(request)
+    if client_ip:
+        _stats["visitors"].add(_anonymise_ip(client_ip))
     _persist_stats()
 
     return {"route": coords, "listings": results}
@@ -359,7 +370,11 @@ async def route_search(req: RouteSearchRequest, request: Request) -> dict:
 
 @app.get("/stats")
 @app.get("/api/stats")
-def stats() -> dict[str, int]:
+def stats(request: Request) -> dict[str, int]:
+    client_ip = _get_client_ip(request)
+    if client_ip:
+        _stats["visitors"].add(_anonymise_ip(client_ip))
+        _persist_stats()
     return {
         "searches_saved": _stats["searches_saved"],
         "listings_found": _stats["listings_found"],

--- a/web/route.js
+++ b/web/route.js
@@ -86,7 +86,7 @@ async function fetchRateLimits(){
       const parts=[];
       if(stats.searches_saved!=null) parts.push(`gestartete Suchen: ${stats.searches_saved}`);
       if(stats.listings_found!=null) parts.push(`gecrawlte Inserate: ${stats.listings_found}`);
-      if(stats.visitors!=null) parts.push(`Besucher: ${stats.visitors}`);
+      if(stats.visitors!=null) parts.push(`Besucher gesamt: ${stats.visitors}`);
       if(limits.geocode&&limits.geocode.limit&&limits.geocode.remaining&&limits.directions&&limits.directions.limit&&limits.directions.remaining){
         parts.push(`API-Limits Geocode ${limits.geocode.remaining}/${limits.geocode.limit}, Directions ${limits.directions.remaining}/${limits.directions.limit}`);
       }


### PR DESCRIPTION
## Summary
- add helper to resolve client IP via X-Forwarded-For
- count anonymised visitors using the resolved IP and persist in stats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aaf84e9a04832587a7f299b12141dd