### PR TITLE
feat: count visitors using more proxy headers

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -92,8 +92,16 @@ def _anonymise_ip(ip: str) -> str:
 
 
 def _get_client_ip(request: Request) -> Optional[str]:
-    if xff := request.headers.get("X-Forwarded-For"):
-        return xff.split(",")[0].strip()
+    for header in (
+        "X-Forwarded-For",
+        "X-Real-IP",
+        "CF-Connecting-IP",
+        "True-Client-IP",
+    ):
+        if value := request.headers.get(header):
+            if header == "X-Forwarded-For":
+                value = value.split(",")[0]
+            return value.strip()
     if request.client:
         return request.client.host
     return None

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -25,6 +25,16 @@ def test_unique_visitors_via_header(monkeypatch, tmp_path):
     assert resp.json()["visitors"] == 2
 
 
+def test_unique_visitors_via_x_real_ip(monkeypatch, tmp_path):
+    client = _get_client(monkeypatch, tmp_path)
+    resp = client.get("/stats", headers={"X-Real-IP": "1.2.3.4"})
+    assert resp.json()["visitors"] == 1
+    resp = client.get("/stats", headers={"X-Real-IP": "1.2.3.4"})
+    assert resp.json()["visitors"] == 1
+    resp = client.get("/stats", headers={"X-Real-IP": "5.6.7.8"})
+    assert resp.json()["visitors"] == 2
+
+
 def test_visitors_fallback_client_host(monkeypatch, tmp_path):
     client = _get_client(monkeypatch, tmp_path)
     resp = client.get("/stats")


### PR DESCRIPTION
## Summary
- handle more proxy headers like X-Real-IP and Cloudflare's CF-Connecting-IP when tracking unique visitors
- test visitor counting via X-Real-IP

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aafd7d8a848325b3d18f14a696eacf